### PR TITLE
PT-3107: Fixed path to bump versions action in Publish workflow

### DIFF
--- a/.github/actions/bump-versions-action/action.yml
+++ b/.github/actions/bump-versions-action/action.yml
@@ -14,6 +14,7 @@ runs:
       # Bump versions using the built-in git token https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#push-a-commit-using-the-built-in-token
       shell: bash
       run: |
+        cd ${GITHUB_ACTION_PATH}/../../..
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         npm run bump-versions -- ${{ inputs.newVersion }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Bump repo versions
         if: ${{ inputs.newVersionAfterPublishing != '' }}
-        uses: ./.github/actions/bump-versions-action
+        uses: ./extension-repo/.github/actions/bump-versions-action
         with:
           newVersion: ${{ inputs.newVersionAfterPublishing }}
 


### PR DESCRIPTION
Fixes bumping at the end of publish https://github.com/paranext/platform-bible-sample-extensions/actions/runs/17332541749/job/49211639564

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/platform-bible-sample-extensions/50)
<!-- Reviewable:end -->
